### PR TITLE
quick fix of the newShare expected number vs hex string

### DIFF
--- a/secrets.js
+++ b/secrets.js
@@ -934,14 +934,15 @@
         // `id` can be a Number or a String in the default radix (16)
         newShare: function (id, shares) {
             var share;
+            var hexid;
 
-            if (id && typeof id === "string") {
-                id = parseInt(id, config.radix);
+            if (id && typeof id === "number") {
+                hexid = id.toString(config.radix);
             }
 
             if (id && shares && shares[0]) {
                 share = this.extractShareComponents(shares[0]);
-                return constructPublicShareString(share.bits, id, this.combine(shares, id));
+                return constructPublicShareString(share.bits, hexid, this.combine(shares, id));
             }
 
             throw new Error("Invalid 'id' or 'shares' Array argument to newShare().");


### PR DESCRIPTION
When generating a new share using `newShare` there are conflicting uses of number vs hex string. `constructPublicShareString` is expecting a hex string of `config.radix` and `this.combine` uses the number. I put the following in, so that passing a number in `newShare` results in the correct share generation.