### PR TITLE
added return type for '_reset()'

### DIFF
--- a/secrets.js.d.ts
+++ b/secrets.js.d.ts
@@ -94,7 +94,7 @@ export function share(
  */
 export function newShare(id: number, shares: Shares): string
 
-export function _reset()
+export function _reset(): void
 
 /**
  * Pads a string `str` with zeros on the left so that its length is a multiple of `bits`


### PR DESCRIPTION
for making d.ts clear, declared return type for _reset() function.

![image](https://user-images.githubusercontent.com/5516480/67473815-50a09180-f68e-11e9-8235-f9989f4f8ad1.png)

This can resolve TS7010.